### PR TITLE
[IMP] Move optional libraries in /opt instead of /root.

### DIFF
--- a/tasks/reportlab.yml
+++ b/tasks/reportlab.yml
@@ -2,7 +2,7 @@
 # Download and install the barcode fonts from ReportLab
 - name: Download the ReportLab barcode fonts
   get_url: url="{{ odoo_reportlab_font_url }}"
-           dest="/root/pfbfer.zip"
+           dest="/opt/pfbfer.zip"
 
 - name: Create the font directory
   file: path="/home/{{ odoo_user }}/fonts" state=directory
@@ -11,7 +11,7 @@
   apt: name=unzip state=installed
 
 - name: Unzip the ReportLab fonts
-  unarchive: src="/root/pfbfer.zip"
+  unarchive: src="/opt/pfbfer.zip"
              dest="/home/{{ odoo_user }}/fonts"
              owner={{ odoo_user }}
              group={{ odoo_user }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -25,7 +25,7 @@ odoo_wkhtmltox_urls:
     # generic tar.gz packages
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz
 
-odoo_wkhtmltox_dest: "/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}"
+odoo_wkhtmltox_dest: "/opt/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}"
 
 # == NodeJS + npm ==
 odoo_nodejs_apt_package: "nodejs=0.10*"


### PR DESCRIPTION
At the moment, optional libs are placed in /root as mentioned in #19.
This pr implements the modification and place those libraries into /opt instead of /root.