### PR TITLE
Handling systemd restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,8 @@
     name: "{{ odoo_service }}"
     state: restarted
   when: odoo_init == True
+
+- name: Reload Systemd
+  systemd:
+    daemon-reload: yes
+  when: ansible_service_mgr == 'systemd'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -17,7 +17,9 @@
             force=yes
             backup=yes
       when: ansible_service_mgr == 'systemd'
-      notify: Restart Odoo
+      notify:
+      - Reload Systemd
+      - Restart Odoo
   when: odoo_install_type == 'standard'
 
 - block:
@@ -37,7 +39,9 @@
             force=yes
             backup=yes
       when: ansible_service_mgr == 'systemd'
-      notify: Restart Odoo
+      notify:
+      - Reload Systemd
+      - Restart Odoo
   when: odoo_install_type == 'buildout'
 
 - block:
@@ -57,7 +61,9 @@
             force=yes
             backup=yes
       when: ansible_service_mgr == 'systemd'
-      notify: Restart Odoo
+      notify:
+      - Reload Systemd
+      - Restart Odoo
   when: odoo_install_type == 'pip'
 
 - name: Enable Odoo service


### PR DESCRIPTION
Fixes #77 .

Please allow me to suggest this change to ensure that systemd gets reloaded after there was a change in the odoo.service file that defines Odoo as a systemd service. Otherwise, changes to that file won't be recognized.

Please test!