### PR TITLE
[FIX] pip install type: require 'pip >= 9.0.1' to not trigger 'changed' event on each playbook execution

### DIFF
--- a/vars/Debian-8_Odoo-10.yml
+++ b/vars/Debian-8_Odoo-10.yml
@@ -53,7 +53,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Debian-8_Odoo-8.yml
+++ b/vars/Debian-8_Odoo-8.yml
@@ -40,7 +40,7 @@ odoo_debian_packages:
 odoo_npm_packages: []
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Debian-8_Odoo-9.yml
+++ b/vars/Debian-8_Odoo-9.yml
@@ -48,7 +48,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-14_Odoo-10.yml
+++ b/vars/Ubuntu-14_Odoo-10.yml
@@ -53,7 +53,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-14_Odoo-8.yml
+++ b/vars/Ubuntu-14_Odoo-8.yml
@@ -38,7 +38,7 @@ odoo_debian_packages:
     - python-gevent
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-14_Odoo-9.yml
+++ b/vars/Ubuntu-14_Odoo-9.yml
@@ -48,7 +48,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-16_Odoo-10.yml
+++ b/vars/Ubuntu-16_Odoo-10.yml
@@ -53,7 +53,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-16_Odoo-11.yml
+++ b/vars/Ubuntu-16_Odoo-11.yml
@@ -57,7 +57,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover
     - setuptools-odoo

--- a/vars/Ubuntu-16_Odoo-8.yml
+++ b/vars/Ubuntu-16_Odoo-8.yml
@@ -38,7 +38,7 @@ odoo_debian_packages:
     - python-gevent
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1

--- a/vars/Ubuntu-16_Odoo-9.yml
+++ b/vars/Ubuntu-16_Odoo-9.yml
@@ -48,7 +48,7 @@ odoo_npm_packages:
       version: 2.1.15
 
 odoo_pip_dependencies:
-    - pip==9.0.1
+    - pip>=9.0.1
     - wrapt
     - odoo-autodiscover==2.0.0
     - setuptools-odoo==2.0.2.post1


### PR DESCRIPTION
Problem:
The task "Install Odoo dependencies (PyPi)" was installing `pip==9.0.1` as specified in the `odoo_pip_dependencies` while the next task "Install Odoo from pip external requirements file" force the installation of `pip` 9.0.2 which has been released a couple a days (https://pypi.python.org/pypi/pip/9.0.2) resulting in a "changed" state.
All Odoo releases seems affected on Debian Jessie, Ubuntu Trusty and Ubuntu Xenial (not Debian Stretch which already provides `pip>=9`).

Errors available on Travis: https://travis-ci.org/OCA/ansible-odoo/builds/355308939

Fix:
Install `pip>=9.0.1` (the 9.0.2 should be installed in new environnements, while the existing ones will be upgraded to `pip==9.0.2` when executing the "Install Odoo from pip external requirements file" task.



ping @jbeficent 