### PR TITLE
[FIX] On Debian Stretch and Ubuntu Xenial, the 'virtualenv' command…

### DIFF
--- a/vars/Debian-9_Odoo-10.yml
+++ b/vars/Debian-9_Odoo-10.yml
@@ -78,7 +78,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev

--- a/vars/Debian-9_Odoo-11.yml
+++ b/vars/Debian-9_Odoo-11.yml
@@ -72,7 +72,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python3-virtualenv
+    - virtualenv
     - build-essential
     - python3-dev
     - libxml2-dev

--- a/vars/Debian-9_Odoo-8.yml
+++ b/vars/Debian-9_Odoo-8.yml
@@ -65,7 +65,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev

--- a/vars/Debian-9_Odoo-9.yml
+++ b/vars/Debian-9_Odoo-9.yml
@@ -74,7 +74,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev

--- a/vars/Ubuntu-16_Odoo-10.yml
+++ b/vars/Ubuntu-16_Odoo-10.yml
@@ -76,7 +76,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev

--- a/vars/Ubuntu-16_Odoo-11.yml
+++ b/vars/Ubuntu-16_Odoo-11.yml
@@ -80,7 +80,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python3-virtualenv
+    - virtualenv
     - build-essential
     - python3-dev
     - libxml2-dev

--- a/vars/Ubuntu-16_Odoo-8.yml
+++ b/vars/Ubuntu-16_Odoo-8.yml
@@ -61,7 +61,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev

--- a/vars/Ubuntu-16_Odoo-9.yml
+++ b/vars/Ubuntu-16_Odoo-9.yml
@@ -71,7 +71,7 @@ odoo_pip_build_dependencies:
     - libssl-dev
 
 odoo_buildout_build_dependencies:
-    - python-virtualenv
+    - virtualenv
     - build-essential
     - python-dev
     - libxml2-dev


### PR DESCRIPTION
…is now provided by the `virtualenv` Debian package.

Right now it works well on Travis CI when testing the role on Debian Stretch and Ubuntu Xenial because the `virtualenv` package has been installed indirectly by the script which install Ansible locally* (it installs `python-virtualenv` which has `virtualenv` as recommended package).
But a real deployment on a vanilla Debian Stretch/Ubuntu Xenial fails.

This fix ensures that the `virtualenv` Debian package is installed on Debian Stretch and Ubuntu Xenial.

* https://github.com/OCA/ansible-odoo/blob/master/tests/install_test_env.sh#L7