### PR TITLE
[IMP] New options 'odoo_user_ssh_key' and 'odoo_user_ssh_known_hosts'…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -121,5 +121,22 @@ odoo_buildout_odoo_bin_path: "{{ odoo_workdir }}/bin/start_odoo"
 odoo_buildout_extra_dependencies: []    # Extra Debian packages required
                                         # to run your Buildout recipe
 
-# Extra options
-odoo_user_sshkeys: ""       # ../../path/to/public_keys/*
+# SSH configuration options
+odoo_user_ssh_dir: "/home/{{ odoo_user }}/.ssh"
+odoo_user_ssh_key: {}
+    # This option set only a pair of private key (/!\ without password /!\)
+    # and public key saved as 'id_rsa{.pub}' (default path) allowing version
+    # control like Git to clone repositories without configuring the ssh-agent.
+    # Example:
+    # odoo_user_ssh_key:
+    #   priv: "path/to/private_key"
+    #   pub:  "path/to/public_key.pub"
+odoo_user_ssh_known_hosts_file: "{{ odoo_user_ssh_dir }}/known_hosts"
+odoo_user_ssh_known_hosts: []
+    # This option add hosts fingerprint to the 'known_hosts' file. Example:
+    # odoo_user_ssh_known_hosts:
+    #   - bitbucket.org
+    #
+# FIXME: 'odoo_user_sshkeys' option (and the underlying task) needs refactoring
+# to handle the state of SSH public keys (present/absent).
+odoo_user_sshkeys: ""       # ./path/to/public_keys/*

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,6 +19,11 @@
   tags:
     - odoo_user
 
+- name: Configure SSH for the Odoo user
+  import_tasks: install_ssh.yml
+  tags:
+    - odoo_install_ssh
+
 - name: Create log directory
   file: path={{ odoo_logdir }} state=directory
         owner={{ odoo_user }} group={{ odoo_user }} force=no
@@ -89,8 +94,3 @@
   tags:
     - odoo
     - odoo_packages
-
-- import_tasks: install_extra.yml
-  when: odoo_user_sshkeys is defined and odoo_user_sshkeys
-  tags:
-    - odoo_install_extra

--- a/tasks/install_extra.yml
+++ b/tasks/install_extra.yml
@@ -1,9 +1,0 @@
----
-
-- name: Set SSH public keys for the Odoo user
-  authorized_key: user={{ odoo_user }}
-                  key="{{ lookup('file', item) }}"
-  with_fileglob:
-    - "{{ odoo_user_sshkeys }}"
-  tags:
-    - odoo_ssh

--- a/tasks/install_ssh.yml
+++ b/tasks/install_ssh.yml
@@ -1,0 +1,54 @@
+---
+
+- block:
+
+    - name: SSH - Install private and public keys for the Odoo user
+      copy:
+        src: "{{ item.value }}"
+        dest: "{{ odoo_user_ssh_dir }}/id_rsa{{ '.pub' if item.key == 'pub' else '' }}"
+        mode: "{{ '0600' if item.key == 'priv' else '0644' }}"
+      with_dict: "{{ odoo_user_ssh_key }}"
+
+    - name: SSH - Remove private and public keys if none is defined
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_list:
+          - "{{ odoo_user_ssh_dir }}/id_rsa"
+          - "{{ odoo_user_ssh_dir }}/id_rsa.pub"
+      when: not odoo_user_ssh_key
+
+    - name: SSH - Make sure the SSH directory exists
+      file:
+        path: "{{ odoo_user_ssh_dir }}"
+        state: directory
+        mode: 0700
+      changed_when: no
+
+    - name: SSH - Make sure the known_hosts file exists
+      file:
+        path: "{{ odoo_user_ssh_known_hosts_file }}"
+        state: touch
+      changed_when: no
+
+    - name: SSH - Check host name availability in the known hosts file
+      shell: "ssh-keygen -f {{ odoo_user_ssh_known_hosts_file }} -F {{ item }}"
+      with_items: "{{ odoo_user_ssh_known_hosts }}"
+      register: odoo_user_ssh_known_host_results
+      ignore_errors: yes
+      changed_when: no
+
+    - name: SSH - Scan hosts public keys
+      shell: "{{ odoo_ssh_keyscan_cmd}} {{ item.item }} >> {{ odoo_user_ssh_known_hosts_file }}"
+      when: item.stdout == ""
+      with_items: "{{ odoo_user_ssh_known_host_results.results }}"
+
+    - name: Set SSH public keys for the Odoo user
+      authorized_key:
+        user: "{{ odoo_user }}"
+        key: "{{ lookup('file', item) }}"
+      with_fileglob:
+        - "{{ odoo_user_sshkeys }}"
+
+  become: yes
+  become_user: "{{ odoo_user }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -37,3 +37,6 @@ odoo_nodejs_apt_repositories:
 odoo_nodejs_apt_keys:
     - url: http://deb.nodesource.com/gpgkey/nodesource.gpg.key
       state: present
+
+# SSH
+odoo_ssh_keyscan_cmd: "ssh-keyscan -H -T 10"


### PR DESCRIPTION
… to configure/copy SSH private (without passphrase) and public keys with the Odoo user allowing to clone private Git/Mercurial repositories (via the `odoo_repo_url` or indirectly with `buildout` install type).

The public key should be added on the different services (BitBucket, GitHub, GitLab...).

Fixing #82 

```yaml
odoo_user_ssh_key:
    priv: "path/to/local/private_key"
    pub:  "path/to/local/public_key.pub"
odoo_user_ssh_known_hosts:
    - bitbucket.org
    - github.com
    - gitlab.com
    - src.company.net
```

Ping @aheficent