### PR TITLE
add option to force reinstall pip packages in pip install method

### DIFF
--- a/tasks/install_pip.yml
+++ b/tasks/install_pip.yml
@@ -38,7 +38,7 @@
   become_user: "{{ odoo_user }}"
   pip:
     requirements: /home/{{ odoo_user }}/requirements.txt
-    extra_args: --upgrade
+    state: forcereinstall
     virtualenv: "{{ odoo_pip_venv_path }}"
   notify: Restart Odoo
 


### PR DESCRIPTION
This option is required to ensure that the latest OCA modules are always installed. Otherwise you get errors when a new version of an OCA module is released.

For example, when you specify in the requirements file this package:
odoo11-addon-auth_brute_force

This will install in fact the latest package from https://wheelhouse.odoo-community.org/oca-simple/odoo10-addon-auth-brute-force/

The next time you run ansible, if a new version of the module has been released, you will want to install it. 

The current --upgrade option is giving errors because it is still expecting older versions of packages. 

This will increase the time to run the playbook, but it is way more reliable IMHO.

Perhaps @sbidoul knows better.