### PR TITLE
force the creation of odoo_workdir and odoo_rootdir

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -62,6 +62,14 @@
   tags:
     - odoo_project
 
+- name: Create working dir directory
+  file: path={{ odoo_workdir }} state=directory
+        owner={{ odoo_user }} group={{ odoo_user }} force=yes
+
+- name: Create odoo server directory
+  file: path={{ odoo_rootdir }} state=directory
+        owner={{ odoo_user }} group={{ odoo_user }} force=yes
+
 - name: Create odoo data dir directory
   file: path={{ odoo_config_data_dir }} state=directory
         owner={{ odoo_user }} group={{ odoo_user }} force=yes


### PR DESCRIPTION
The parameters 'odoo_workdir', 'odoo_rootdir' and 'odoo_config_data_dir' are defaulted to be under /home/{odoo user}
https://github.com/OCA/ansible-odoo/blob/bb855f416c640c21f1268b9dd6540b77a147466d/defaults/main.yml#L17

But that is not the correct to place applications, according to https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard. In /home one should store user's personal files, not applications.

In my opinion a better place, according to my interpretation of the filesystem hierarchy standard, should be:
odoo_workdir: "/opt/odoo"
odoo_rootdir: "/opt/odoo/server"
odoo_config_data_dir: "/srv/odoo"

I can agree that this may not be necessarily the defaulted values. But the problem comes when I change the parameters to what I indicated above. In that case the playbook fails because there's no explicit task in the playbook that creates the odoo_workdir or odoo_rootdir.

This PR fixes that, with the following results in the ansible playbook execution log:

TASK [ansible-odoo : Create working dir directory] *****************************
changed: [odoo11] => {"changed": true, "gid": 1000, "group": "odoo", "mode": "0755", "owner": "odoo", "path": "/opt/odoo", "size": 4096, "state": "directory", "uid": 1000}

TASK [ansible-odoo : Create odoo server directory] *****************************
changed: [odoo11] => {"changed": true, "gid": 1000, "group": "odoo", "mode": "0755", "owner": "odoo", "path": "/opt/odoo/server", "size": 4096, "state": "directory", "uid": 1000}
