### PR TITLE
[FIX] templates Python 3 compat

### DIFF
--- a/templates/odoo-10.0.init
+++ b/templates/odoo-10.0.init
@@ -26,7 +26,7 @@ USER={{ odoo_user }}
 export LOGNAME=$USER
 {% if odoo_init_env %}
 # Custom environment variables
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 export {{ name }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/odoo-8.0.init
+++ b/templates/odoo-8.0.init
@@ -26,7 +26,7 @@ USER={{ odoo_user }}
 export LOGNAME=$USER
 {% if odoo_init_env %}
 # Custom environment variables
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 export {{ name }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/odoo-9.0.init
+++ b/templates/odoo-9.0.init
@@ -26,7 +26,7 @@ USER={{ odoo_user }}
 export LOGNAME=$USER
 {% if odoo_init_env %}
 # Custom environment variables
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 export {{ name }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/odoo-buildout.init
+++ b/templates/odoo-buildout.init
@@ -25,7 +25,7 @@ USER={{ odoo_user }}
 export LOGNAME=$USER
 {% if odoo_init_env %}
 # Custom environment variables
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 export {{ name }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/odoo-buildout.service
+++ b/templates/odoo-buildout.service
@@ -8,7 +8,7 @@ User={{ odoo_user }}
 WorkingDirectory={{ odoo_workdir }}
 ExecStart={{ odoo_buildout_odoo_bin_path }}{{ odoo_logfile and ' --logfile %s' % odoo_logfile }}
 KillMode=mixed
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 Environment={{ name }}={{ value }}
 {% endfor %}
 

--- a/templates/odoo-pip.init
+++ b/templates/odoo-pip.init
@@ -27,7 +27,7 @@ USER={{ odoo_user }}
 export LOGNAME=$USER
 {% if odoo_init_env %}
 # Custom environment variables
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 export {{ name }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/odoo-pip.service
+++ b/templates/odoo-pip.service
@@ -8,7 +8,7 @@ User={{ odoo_user }}
 WorkingDirectory={{ odoo_workdir }}
 ExecStart={{ odoo_pip_odoo_bin_path }}{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
 KillMode=mixed
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 Environment={{ name }}={{ value }}
 {% endfor %}
 

--- a/templates/odoo-standard.service
+++ b/templates/odoo-standard.service
@@ -12,7 +12,7 @@ KillMode=mixed
 {% else %}
 ExecStart={{ odoo_rootdir }}/odoo.py{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
 {% endif %}
-{% for name, value in odoo_init_env.iteritems() %}
+{% for name, value in odoo_init_env.items() | list %}
 Environment={{ name }}={{ value }}
 {% endfor %}
 


### PR DESCRIPTION
Fixing `iteritems()` removal in Python 3 replacing by `items()` and `list` Jinja filter.

See more:
https://docs.ansible.com/ansible/2.6/user_guide/playbooks_python_version.html#pb-py-compat-dict-views