### PR TITLE
[FIX] Upgraded Wkhtmltopdf to 0.12.5

### DIFF
--- a/vars/Debian-9_Odoo-10.yml
+++ b/vars/Debian-9_Odoo-10.yml
@@ -93,7 +93,7 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
-odoo_wkhtmltox_version: 0.12.4
+odoo_wkhtmltox_version: 0.12.5
 
 odoo_wkhtmltox_depends:
     - fontconfig

--- a/vars/Debian-9_Odoo-11.yml
+++ b/vars/Debian-9_Odoo-11.yml
@@ -90,7 +90,7 @@ odoo_buildout_build_dependencies:
 odoo_buildout_venv_cmd: "python3 -m virtualenv --no-setuptools --python=python3 {{ odoo_buildout_venv_path }}"
 odoo_pip_venv_cmd: "python3 -m virtualenv --python=python3 {{ odoo_pip_venv_path }}"
 
-odoo_wkhtmltox_version: 0.12.4
+odoo_wkhtmltox_version: 0.12.5
 
 odoo_wkhtmltox_depends:
     - fontconfig

--- a/vars/Debian-9_Odoo-8.yml
+++ b/vars/Debian-9_Odoo-8.yml
@@ -80,7 +80,7 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
-odoo_wkhtmltox_version: 0.12.4
+odoo_wkhtmltox_version: 0.12.5
 
 odoo_wkhtmltox_depends:
     - fontconfig

--- a/vars/Debian-9_Odoo-9.yml
+++ b/vars/Debian-9_Odoo-9.yml
@@ -89,7 +89,7 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
-odoo_wkhtmltox_version: 0.12.4
+odoo_wkhtmltox_version: 0.12.5
 
 odoo_wkhtmltox_depends:
     - fontconfig

--- a/vars/Ubuntu-16_Odoo-11.yml
+++ b/vars/Ubuntu-16_Odoo-11.yml
@@ -98,7 +98,7 @@ odoo_buildout_build_dependencies:
 odoo_buildout_venv_cmd: "virtualenv --no-setuptools --python=python3 {{ odoo_buildout_venv_path }}"
 odoo_pip_venv_cmd: "virtualenv --python=python3 {{ odoo_pip_venv_path }}"
 
-odoo_wkhtmltox_version: 0.12.4
+odoo_wkhtmltox_version: 0.12.5
 
 odoo_wkhtmltox_depends:
     - fontconfig


### PR DESCRIPTION
Odoo/Distribution installed with wkhtmltopdf 0.12.1 are left unchanged, only 0.12.4 are migrated to 0.12.5.