### PR TITLE
[UPD] Configure which pip executable to use with `odoo_pip_executable`.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ansible_ssh_pipelining: true
 
 odoo_install_type: standard     # standard, buildout
+odoo_pip_executable: "pip"
 odoo_version: 11.0
 odoo_service: odoo
 odoo_user: odoo

--- a/tasks/install_standard.yml
+++ b/tasks/install_standard.yml
@@ -10,7 +10,9 @@
     - odoo_packages
 
 - name: Install Odoo dependencies (PyPi)
-  pip: name={{ item }}
+  pip:
+    name: "{{ item }}"
+    executable: "{{ odoo_pip_executable }}"
   with_items: "{{ odoo_pypi_packages }}"
   tags:
     - odoo_packages

--- a/vars/Ubuntu-16_Odoo-11.yml
+++ b/vars/Ubuntu-16_Odoo-11.yml
@@ -40,6 +40,7 @@ odoo_debian_packages:
     - python3-xlsxwriter
     - python3-yaml
 
+odoo_pip_executable: "pip3"
 odoo_pypi_packages:
     - psycogreen
     - qrcode


### PR DESCRIPTION
Configure which pip executable to use with variable odoo_pip_executable.
For example in Ubuntu 18.x the "pip command" is still linked with Python2.7.