### PR TITLE
[IMP] Configurable odoo_rootdir. New odoo_serverdir is former odoo_rootdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ the same host):
     - role: odoo
       odoo_version: 11.0
       odoo_config_admin_passwd: SuPerPassWorD
+
+      ## Recommended directories
+      ## Default/legacy settings to maintain backwards compatibility,
+      ## so existing deployments won't break.
+      # odoo_rootdir: /opt/odoo  # Default/legacy "/home/{{ odoo_user }}"
+      # odoo_config_data_dir: "/srv/odoo"  # Default/legacy "/home/{{ odoo_user }}/.local/share/Odoo"
 ```
 
 With the standard installation type you configure Odoo with the available
@@ -66,6 +72,12 @@ available from your Ansible inventory):
       odoo_config_db_host: pg_server
       odoo_config_db_user: odoo
       odoo_config_db_passwd: PaSsWoRd
+
+      ## Recommended directories
+      ## Default/legacy settings to maintain backwards compatibility,
+      ## so existing deployments won't break.
+      # odoo_rootdir: /opt/odoo  # Default/legacy "/home/{{ odoo_user }}"
+      # odoo_config_data_dir: "/srv/odoo"  # Default/legacy "/home/{{ odoo_user }}/.local/share/Odoo"
 ```
 
 Standard installation from a personnal Git repository such as your repository
@@ -96,11 +108,11 @@ Here we set some options required by the ``connector`` framework:
         ODOO_CONNECTOR_CHANNELS: root:2
       odoo_config_admin_passwd: SuPerPassWorD
       odoo_config_addons_path:
-        - "/home/{{ odoo_user }}/odoo/server/openerp/addons"
-        - "/home/{{ odoo_user }}/odoo/server/addons"
-        - "/home/{{ odoo_user }}/odoo/addons_oca_web"
-        - "/home/{{ odoo_user }}/odoo/addons_oca_connector"
-        - "/home/{{ odoo_user }}/odoo/addons"
+        - "{{ odoo_workdir }}/odoo/server/openerp/addons"
+        - "{{ odoo_workdir }}/odoo/server/addons"
+        - "{{ odoo_workdir }}/odoo/addons_oca_web"
+        - "{{ odoo_workdir }}/odoo/addons_oca_connector"
+        - "{{ odoo_workdir }}/odoo/addons"
       odoo_config_server_wide_modules: web,web_kanban,connector
       odoo_config_workers: 8
 ```
@@ -143,7 +155,7 @@ by Buildout:
       odoo_repo_type: git
       odoo_repo_url: https://github.com/osiell/odoo-buildout-example.git
       odoo_repo_rev: "{{ odoo_version }}"
-      odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
+      odoo_repo_dest: "{{ odoo_workdir }}/odoo"
 ```
 
 The same but with PostgreSQL installed on a remote host (and available from
@@ -160,7 +172,7 @@ your Ansible inventory):
       odoo_repo_type: git
       odoo_repo_url: https://github.com/osiell/odoo-buildout-example.git
       odoo_repo_rev: "{{ odoo_version }}"
-      odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
+      odoo_repo_dest: "{{ odoo_workdir }}/odoo"
       odoo_config_db_host: pg_server
       odoo_config_db_user: odoo
       odoo_config_db_passwd: PaSsWoRd
@@ -195,9 +207,9 @@ We just set the relevant options to tell Ansible the files to use with the
       odoo_repo_type: git
       odoo_repo_url: https://SERVER/REPO
       odoo_repo_rev: master
-      odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
-      odoo_buildout_bootstrap_path: "/home/{{ odoo_user }}/odoo/bin/bootstrap.py"
-      odoo_buildout_config_path: "/home/{{ odoo_user }}/odoo/buildout.prod.cfg"
+      odoo_repo_dest: "{{ odoo_workdir }}/odoo"
+      odoo_buildout_bootstrap_path: "{{ odoo_workdir }}/odoo/bin/bootstrap.py"
+      odoo_buildout_config_path: "{{ odoo_workdir }}/odoo/buildout.prod.cfg"
 ```
 
 ## Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,15 +12,18 @@ odoo_init: True
 odoo_init_env: {}
     #VAR1: value1
     #VAR2: value2
+odoo_rootdir: "/home/{{ odoo_user }}"  # Recommended: /opt/odoo
+    # This default is a legacy setting, to maintain backwards
+    # compatibility, so existing deployments won't break.
+odoo_workdir: "{{ odoo_rootdir }}/odoo"
+odoo_serverdir: "{{ odoo_install_type == 'buildout' and odoo_rootdir+'/'+odoo_user+'/odoo/parts/odoo' or odoo_rootdir+'/'+odoo_user+'/server' }}"
 odoo_logdir: "/var/log/{{ odoo_user }}"
 odoo_logfile: "{{ ansible_service_mgr != 'systemd' and ('/'.join([odoo_logdir, odoo_service]) + '.log') or ''}}"
-odoo_workdir: "/home/{{ odoo_user }}/odoo"
-odoo_rootdir: "{{ odoo_install_type == 'buildout' and '/home/'+odoo_user+'/odoo/parts/odoo' or '/home/'+odoo_user+'/odoo/server' }}"
 
 # Project repository to deploy
 odoo_repo_type: git     # git or hg
 odoo_repo_url: "{{ odoo_install_type == 'buildout' and 'https://github.com/osiell/odoo-buildout-example.git' or 'https://github.com/odoo/odoo.git' }}"
-odoo_repo_dest: "{{ odoo_install_type == 'buildout' and odoo_workdir or odoo_rootdir }}"
+odoo_repo_dest: "{{ odoo_install_type == 'buildout' and odoo_workdir or odoo_serverdir }}"
 odoo_repo_rev: "{{ odoo_version }}"
 odoo_repo_update: True  # Update the working copy or not. This option is
                         # ignored on the first run (a checkout of the working
@@ -39,15 +42,18 @@ odoo_postgresql_extensions:
     - unaccent
 
 # Standard installation/configuration options (odoo_install_type == 'standard')
-odoo_config_file: "/home/{{ odoo_user }}/{{ odoo_service }}.conf"
+odoo_config_file: "/etc/{{ odoo_service }}.conf"
 odoo_force_config: True
 odoo_config_addons_path:
-    - "/home/{{ odoo_user }}/odoo/server/{{ (odoo_version | int) < 10 and 'openerp' or 'odoo' }}/addons"
-    - "/home/{{ odoo_user }}/odoo/server/addons"
+    - "{{ odoo_workdir }}/server/{{ (odoo_version | int) < 10 and 'openerp' or 'odoo' }}/addons"
+    - "{{ odoo_workdir }}/server/addons"
 odoo_config_admin_passwd: admin
 odoo_config_auto_reload: False
 odoo_config_csv_internal_sep: ','
-odoo_config_data_dir: "/home/{{ odoo_user }}/.local/share/Odoo"
+odoo_config_data_dir: "/home/{{ odoo_user }}/.local/share/Odoo"  # Recommended: /srv/odoo
+    # This default is a legacy setting, to maintain backwards
+    # compatibility, so existing deployments won't break.
+
 odoo_config_db_host: False
 odoo_config_db_host_user: "{{ ansible_user }}"
 odoo_config_db_maxconn: 64

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,6 +30,12 @@
   tags:
     - odoo_log
 
+- name: Create Odoo work directory
+  file: path={{ odoo_workdir }} state=directory
+        owner={{ odoo_user }} group={{ odoo_user }} force=no
+  tags:
+    - odoo_project
+
 - name: Project repository already cloned?
   stat: path={{ odoo_repo_dest }}
   register: project_path

--- a/tasks/reportlab.yml
+++ b/tasks/reportlab.yml
@@ -5,16 +5,16 @@
            dest="/opt/pfbfer.zip"
 
 - name: Create the font directory
-  file: path="/home/{{ odoo_user }}/fonts" state=directory
+  file: path="{{ odoo_workdir }}/fonts" state=directory
 
 - name: Install unzip
   apt: name=unzip state=present
 
 - name: Unzip the ReportLab fonts
   unarchive: src="/opt/pfbfer.zip"
-             dest="/home/{{ odoo_user }}/fonts"
+             dest="{{ odoo_workdir }}/fonts"
              owner={{ odoo_user }}
              group={{ odoo_user }}
              mode="u=rwX,go=rX"
              copy=No
-             creates="/home/{{ odoo_user }}/fonts/_abi____.pfb"
+             creates="{{ odoo_workdir }}/fonts/_abi____.pfb"

--- a/templates/odoo-10.0.init
+++ b/templates/odoo-10.0.init
@@ -16,7 +16,7 @@
 
 PATH=/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin
 WORKDIR={{ odoo_workdir }}
-DAEMON={{ odoo_rootdir }}/odoo-bin
+DAEMON={{ odoo_serverdir }}/odoo-bin
 NAME={{ odoo_service }}
 DESC={{ odoo_service }}
 CONFIG={{ odoo_config_file }}

--- a/templates/odoo-8.0.init
+++ b/templates/odoo-8.0.init
@@ -16,7 +16,7 @@
 
 PATH=/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin
 WORKDIR={{ odoo_workdir }}
-DAEMON={{ odoo_rootdir }}/odoo.py
+DAEMON={{ odoo_serverdir }}/odoo.py
 NAME={{ odoo_service }}
 DESC={{ odoo_service }}
 CONFIG={{ odoo_config_file }}

--- a/templates/odoo-9.0.init
+++ b/templates/odoo-9.0.init
@@ -16,7 +16,7 @@
 
 PATH=/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin
 WORKDIR={{ odoo_workdir }}
-DAEMON={{ odoo_rootdir }}/odoo.py
+DAEMON={{ odoo_serverdir }}/odoo.py
 NAME={{ odoo_service }}
 DESC={{ odoo_service }}
 CONFIG={{ odoo_config_file }}

--- a/templates/odoo-standard.service
+++ b/templates/odoo-standard.service
@@ -7,10 +7,10 @@ Type=simple
 User={{ odoo_user }}
 WorkingDirectory={{ odoo_workdir }}
 {% if odoo_version | version_compare('10.0', '>=') %}
-ExecStart={{ odoo_rootdir }}/odoo-bin{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
+ExecStart={{ odoo_serverdir }}/odoo-bin{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
 KillMode=mixed
 {% else %}
-ExecStart={{ odoo_rootdir }}/odoo.py{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
+ExecStart={{ odoo_serverdir }}/odoo.py{{ odoo_logfile and ' --logfile %s' % odoo_logfile }} --config {{ odoo_config_file }}
 {% endif %}
 {% for name, value in odoo_init_env.items() | list %}
 Environment={{ name }}={{ value }}


### PR DESCRIPTION
This PR is actually somewhere similar to [PR 90](https://github.com/OCA/ansible-odoo/pull/90)

**Changelog:**
- With a configurable odoo_rootdir one can deploy Odoo according to the filesystem hier/standards - e.g. under /opt/odoo.
- Task which creates the {{ odoo_workdir }}
- Recommendation regarding the {{ odoo_config_data_dir }}, to comply with the filesystem hier/standards (e.g. /srv/odoo).
- (Default) odoo_config_file: /etc/{{ odoo_service }}.conf